### PR TITLE
Fix date milliseconds formatting issue

### DIFF
--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -176,35 +176,24 @@ export class QueryFormatter {
     // YYYY-MM-DD HH:mm:ss.mmm
     const yearMonthDay =
       zeroPad(year, 4) + "-" + zeroPad(month, 2) + "-" + zeroPad(day, 2);
-    const hourMinuteSecond =
-      zeroPad(hour, 2) + ":" + zeroPad(minute, 2) + ":" + zeroPad(second, 2);
+    const time =
+      zeroPad(hour, 2) +
+      ":" +
+      zeroPad(minute, 2) +
+      ":" +
+      zeroPad(second, 2) +
+      (millisecond > 0 ? "." + zeroPad(millisecond, 3) : "");
 
     if (param instanceof PGDate) {
       return this.escapeString(yearMonthDay);
     }
 
     if (param instanceof TimestampTZ) {
-      const str =
-        yearMonthDay +
-        " " +
-        hourMinuteSecond +
-        "." +
-        zeroPad(millisecond, 6, "right") +
-        " " +
-        param.timeZone;
+      const str = yearMonthDay + " " + time + " " + param.timeZone;
       return this.escapeString(str);
     }
 
-    if (param instanceof TimestampNTZ) {
-      const str =
-        yearMonthDay +
-        " " +
-        hourMinuteSecond +
-        "." +
-        zeroPad(millisecond, 6, "right");
-      return this.escapeString(str);
-    }
-    const str = yearMonthDay + " " + hourMinuteSecond;
+    const str = yearMonthDay + " " + time;
     return this.escapeString(str);
   }
 
@@ -213,7 +202,7 @@ export class QueryFormatter {
       return this.escapeArray(param.value, "(", ")");
     } else if (BigNumber.isBigNumber(param)) {
       return param.toString();
-    } else if (Object.prototype.toString.call(param) === "[object Date]") {
+    } else if (param instanceof Date) {
       return this.escapeDate(param);
     } else if (Array.isArray(param)) {
       return this.escapeArray(param);

--- a/src/statement/hydrateDate.test.ts
+++ b/src/statement/hydrateDate.test.ts
@@ -85,6 +85,26 @@ describe("hydrate Date", () => {
     expect(second).toEqual(10);
     expect(milliseconds).toEqual(123);
   });
+  it("hydrate few milliseconds", () => {
+    const input = "2033-02-13 12:00:10.01+01:00";
+    const date = hydrateDate(input);
+
+    const year = date?.getUTCFullYear();
+    const month = date?.getUTCMonth();
+    const day = date?.getUTCDate();
+    const hour = date?.getUTCHours();
+    const minute = date?.getUTCMinutes();
+    const second = date?.getUTCSeconds();
+    const milliseconds = date?.getUTCMilliseconds();
+
+    expect(year).toEqual(2033);
+    expect(month).toEqual(1);
+    expect(day).toEqual(13);
+    expect(hour).toEqual(11);
+    expect(minute).toEqual(0);
+    expect(second).toEqual(10);
+    expect(milliseconds).toEqual(10);
+  });
   it("hydrate microseconds", () => {
     const input = "2033-02-13 12:00:10.123456+01:00";
     const date = hydrateDate(input);

--- a/test/unit/statement.test.ts
+++ b/test/unit/statement.test.ts
@@ -110,6 +110,26 @@ describe("format query", () => {
       `"select '1000-01-01 12:21:21' from table"`
     );
   });
+  it("format date with milliseconds", () => {
+    const queryFormatter = new QueryFormatter();
+    const query = "select ?";
+    const formattedQuery = queryFormatter.formatQuery(query, [
+      new TimestampNTZ("2023-12-12 00:00:00.123 UTC")
+    ]);
+    expect(formattedQuery).toMatchInlineSnapshot(
+      `"select '2023-12-12 00:00:00.123'"`
+    );
+  });
+  it("format date with few milliseconds", () => {
+    const queryFormatter = new QueryFormatter();
+    const query = "select ?";
+    const formattedQuery = queryFormatter.formatQuery(query, [
+      new TimestampNTZ("2023-12-12 00:00:00.01 UTC")
+    ]);
+    expect(formattedQuery).toMatchInlineSnapshot(
+      `"select '2023-12-12 00:00:00.010'"`
+    );
+  });
   it("format with comments", () => {
     const queryFormatter = new QueryFormatter();
     const query = "SELECT * FROM table WHERE /* a comment line? */ table.a = 4";
@@ -169,10 +189,10 @@ describe("format query", () => {
       "str"
     ]);
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"insert into foo values('2023-12-12 00:00:00.000000 UTC', 'str')"`
+      `"insert into foo values('2023-12-12 00:00:00 UTC', 'str')"`
     );
   });
-  it("format timestampTZ with microseconds padding", () => {
+  it("format timestampTZ with milliseconds", () => {
     const queryFormatter = new QueryFormatter();
     const query = "insert into foo values(?, ?)";
     const formattedQuery = queryFormatter.formatQuery(query, [
@@ -180,7 +200,7 @@ describe("format query", () => {
       "str"
     ]);
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"insert into foo values('2023-12-12 00:00:00.123000 UTC', 'str')"`
+      `"insert into foo values('2023-12-12 00:00:00.123 UTC', 'str')"`
     );
   });
   it("format timestampNTZ", () => {
@@ -191,10 +211,10 @@ describe("format query", () => {
       "str"
     ]);
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"insert into foo values('2023-12-12 00:00:00.000000', 'str')"`
+      `"insert into foo values('2023-12-12 00:00:00', 'str')"`
     );
   });
-  it("format timestampNTZ with microseconds padding", () => {
+  it("format timestampNTZ with milliseconds", () => {
     const queryFormatter = new QueryFormatter();
     const query = "insert into foo values(?, ?)";
     const formattedQuery = queryFormatter.formatQuery(query, [
@@ -202,7 +222,18 @@ describe("format query", () => {
       "str"
     ]);
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"insert into foo values('2023-12-12 00:00:00.123000', 'str')"`
+      `"insert into foo values('2023-12-12 00:00:00.123', 'str')"`
+    );
+  });
+  it("format timestampNTZ with few milliseconds", () => {
+    const queryFormatter = new QueryFormatter();
+    const query = "insert into foo values(?, ?)";
+    const formattedQuery = queryFormatter.formatQuery(query, [
+      new TimestampNTZ("2023-12-12 00:00:00.01 UTC"),
+      "str"
+    ]);
+    expect(formattedQuery).toMatchInlineSnapshot(
+      `"insert into foo values('2023-12-12 00:00:00.010', 'str')"`
     );
   });
   it("format named parameter", () => {


### PR DESCRIPTION
For a Date like `2023-01-01T00:00:00.010Z` the formatter would previously incorrectly generate `2023-01-01 00:00:00.100000`.