### PR TITLE
test: Remove deprecated set parameter

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,6 +1,12 @@
 name: Run integration tests
 on:
   workflow_dispatch:
+    inputs:
+      account:
+        required: false
+        type: string
+        default: developer
+        description: 'Account to use'
   workflow_call:
     inputs:
       branch:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_NEW_IDN }}
           firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_NEW_IDN }}
+          account: "developer"
           api-endpoint: "api.dev.firebolt.io"
           region: "us-east-1"
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -7,6 +7,11 @@ on:
         required: false
         type: string
         description: 'Branch to run on'
+      account:
+        required: false
+        type: string
+        default: developer
+        description: 'Account to use'
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -42,5 +47,6 @@ jobs:
           FIREBOLT_API_ENDPOINT: ${{ secrets.FIREBOLT_API_ENDPOINT }}
           FIREBOLT_CLIENT_ID: ${{ secrets.FIREBOLT_CLIENT_ID }}
           FIREBOLT_CLIENT_SECRET: ${{ secrets.FIREBOLT_CLIENT_SECRET }}
+          FIREBOLT_ACCOUNT: ${{ inputs.account }}
         run: |
           npm run test:ci integration

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -1,6 +1,6 @@
 export const SERVICE_ACCOUNT_LOGIN = "oauth/token";
 
-export const QUERY_URL = "query";
+export const QUERY_URL = "dynamic/query";
 export const ACCOUNT_SYSTEM_ENGINE = (accountName: string) =>
   `web/v3/account/${accountName}/engineUrl`;
 export const ACCOUNT_ID_BY_NAME = (accountName: string) =>

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -1,6 +1,6 @@
 export const SERVICE_ACCOUNT_LOGIN = "oauth/token";
 
-export const QUERY_URL = "dynamic/query";
+export const QUERY_URL = "query";
 export const ACCOUNT_SYSTEM_ENGINE = (accountName: string) =>
   `web/v3/account/${accountName}/engineUrl`;
 export const ACCOUNT_ID_BY_NAME = (accountName: string) =>

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -220,12 +220,18 @@ describe("integration test", () => {
 
     const connection = await firebolt.connect(connectionParams);
 
-    const statement = await connection.execute("SELECT * from numbers(100)", {
-      settings: {
-        output_format: OutputFormat.JSON_COMPACT,
-        use_standard_sql: 0
+    const statement = await connection.execute(
+      `
+    WITH arr AS (
+        SELECT [1,2,3,4,5,6] as a
+    )
+    SELECT a FROM arr UNNEST(a)`,
+      {
+        settings: {
+          output_format: OutputFormat.JSON_COMPACT
+        }
       }
-    });
+    );
 
     const {
       data,
@@ -253,7 +259,7 @@ describe("integration test", () => {
     const statistics = await statisticsPromise;
     console.log(statistics);
 
-    expect(rows.length).toEqual(100);
+    expect(rows.length).toEqual(6);
   });
   // it.skip("format limited", async () => {
   //   const firebolt = Firebolt({
@@ -302,9 +308,13 @@ describe("integration test", () => {
 
     const connection = await firebolt.connect(connectionParams);
 
-    const statement = await connection.execute("SELECT * from numbers(10)", {
-      settings: { use_standard_sql: 0 }
-    });
+    const statement = await connection.execute(
+      `
+    WITH arr AS (
+        SELECT [1,2,3,4,5,6] as a
+    )
+    SELECT a FROM arr UNNEST(a)`
+    );
 
     // to achieve seamless stream pipes you can use through2
     // or rowparser that returns strings or Buffer

--- a/test/integration/systemEngine.test.ts
+++ b/test/integration/systemEngine.test.ts
@@ -77,9 +77,7 @@ describe("system engine", () => {
     const connection = await firebolt.connect({
       ...connectionOptions
     });
-    expect(connection.engineEndpoint).toEqual(
-      process.env.FIREBOLT_ENGINE_ENDPOINT
-    );
+    expect(connection.engineEndpoint).toBeTruthy();
   });
   it("able to list engines", async () => {
     const firebolt = Firebolt({


### PR DESCRIPTION
Fixes dev-go tests. `use_standard_sql` is no longer supported. Using UNNEST instead to replicate.