### PR TITLE
Fir 27809 services non string parameters

### DIFF
--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -100,8 +100,9 @@ export class EngineService {
     if (options.engine_type == undefined) {
       options.engine_type = EngineType.GENERAL_PURPOSE;
     }
-    let query: string =
-      `CREATE ENGINE ${options.fail_if_exists ? "" : "IF NOT EXISTS "} "${name}"`;
+    let query = `CREATE ENGINE ${
+      options.fail_if_exists ? "" : "IF NOT EXISTS "
+    } "${name}"`;
 
     const allParamValues = [
       options.region,
@@ -111,19 +112,20 @@ export class EngineService {
       options.auto_stop,
       options.warmup
     ];
-    const queryParameters: string[] = [];
+    const queryParameters: (string | number)[] = [];
     if (
-      options.region || 
-      options.engine_type || 
-      options.spec || 
-      options.scale || 
-      options.auto_stop || 
-      options.warmup) {
+      options.region ||
+      options.engine_type ||
+      options.spec ||
+      options.scale ||
+      options.auto_stop ||
+      options.warmup
+    ) {
       query += " WITH ";
       for (const [index, value] of allParamValues.entries()) {
         if (value) {
           query += `${this.CREATE_PARAMETER_NAMES[index]} = ?`;
-          queryParameters.push(value.toString());
+          queryParameters.push(value);
         }
       }
     }

--- a/test/integration/engine.test.ts
+++ b/test/integration/engine.test.ts
@@ -1,8 +1,5 @@
-import {
-  EngineStatusSummary,
-  Firebolt,
-  FireboltResourceManager
-} from "../../src/index";
+import { EngineStatusSummary, Firebolt, FireboltResourceManager } from "../../src/index";
+import { EngineType, WarmupMethod } from "../../src/service/engine/types";
 
 const authOptions = {
   client_id: process.env.FIREBOLT_CLIENT_ID as string,
@@ -94,10 +91,22 @@ describe("engine integration", () => {
     const connection = await firebolt.connect(connectionOptions);
     const name = `${process.env.FIREBOLT_DATABASE}_create_delete`;
 
-    const database = await firebolt.resourceManager.database.create(name);
+    const database = await firebolt.resourceManager.database.create(name, {
+      description: "test database",
+      fail_if_exists: true,
+      region: "us-east-1"
+    });
     expect(database.name == name);
 
-    const engine = await firebolt.resourceManager.engine.create(name);
+    const engine = await firebolt.resourceManager.engine.create(name, {
+      region: "us-east-1",
+      engine_type: EngineType.GENERAL_PURPOSE,
+      spec: "B2",
+      scale: 1,
+      auto_stop: 20 * 60,
+      warmup: WarmupMethod.MINIMAL,
+      fail_if_exists: true
+    });
     expect(engine.name == name);
 
     await firebolt.resourceManager.engine.attachToDatabase(engine, database);


### PR DESCRIPTION
Removed converting engine parameters to a string when creating engines via service