### PR TITLE
Fir 27741 ci pre release

### DIFF
--- a/.github/workflows/release-v0.yaml
+++ b/.github/workflows/release-v0.yaml
@@ -6,6 +6,9 @@ on:
       majorRelease:
         required: false
         description: 'Release as version. Example values are: minor, major, 5.6.1, 1.0.0. Leave empty for regular release.'
+      tag:
+        required: false
+        description: 'Tag name. Leave empty for regular release.'
 
 jobs:
   release:
@@ -13,4 +16,5 @@ jobs:
     with:
       branch: 0.x
       majorRelease: ${{ inputs.majorRelease }}
+      tag: ${{ inputs.tag }}
     secrets: inherit

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -57,7 +57,7 @@ jobs:
         echo //registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_KEY}} >> .npmrc
         echo email=${{ secrets.NPM_EMAIL }} >> .npmrc
         echo always-auth=true >> .npmrc
-        npm publish ${{ github.events.inputs.tag != '' && format('--tag {0}', github.event.inputs.tag) || '' }}
+        npm publish ${{ github.event.inputs.tag != '' && format('--tag {0}', github.event.inputs.tag) || '' }}
 
     - name: Push git tags
       run: |

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -50,14 +50,18 @@ jobs:
 
     - name: Release
       run: |
-        npm run release ${{github.event.inputs.majorRelease != '' && format('-- --release-as {1}', github.event.inputs.majorRelease) || ''}} ${{github.event.inputs.tag != '' && format('--prerelease {1}', github.event.inputs.tag) || ''}}
+        ${{ join(
+        'npm run release',
+        github.event.inputs.majorRelease != '' && format(' -- --release-as {1}', github.event.inputs.majorRelease) || '',
+        github.event.inputs.tag != '' && format(' --prerelease {1}', github.event.inputs.tag) || ''
+        }}
 
     - name: Publish to npm
       run: |
         echo //registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_KEY}} >> .npmrc
         echo email=${{ secrets.NPM_EMAIL }} >> .npmrc
         echo always-auth=true >> .npmrc
-        npm publish ${{ github.events.inputs.tag != '' && format('--tag {1}', github.event.inputs.tag) || '' }}
+        ${{ github.events.inputs.tag != '' && format('npm publish --tag {1}', github.event.inputs.tag) || 'npm publish' }}
 
     - name: Push git tags
       run: |

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -29,6 +29,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ inputs.branch }}
+        token: ${{ secrets.RELEASE_PAT }}
     
     - name: Set up node.js
       uses: actions/setup-node@v2

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
         description: 'main or 0.x branch'
+      tag:
+        required: false
+        type: string
+        description: 'Tag name. Leave empty for regular release.'
 
 jobs:
   # integration-tests:
@@ -46,14 +50,14 @@ jobs:
 
     - name: Release
       run: |
-        ${{github.event.inputs.majorRelease != '' && format('npm run release -- --release-as {1}', github.event.inputs.majorRelease) || 'npm run release'}}
+        npm run release ${{github.event.inputs.majorRelease != '' && format('-- --release-as {1}', github.event.inputs.majorRelease) || ''}} ${{github.event.inputs.tag != '' && format('--prerelease {1}', github.event.inputs.tag) || ''}}
 
     - name: Publish to npm
       run: |
         echo //registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_KEY}} >> .npmrc
         echo email=${{ secrets.NPM_EMAIL }} >> .npmrc
         echo always-auth=true >> .npmrc
-        npm publish
+        npm publish ${{ github.events.inputs.tag != '' && format('--tag {1}', github.event.inputs.tag) || '' }}
 
     - name: Push git tags
       run: |

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -50,11 +50,7 @@ jobs:
 
     - name: Release
       run: |
-        ${{ join(
-        'npm run release',
-        github.event.inputs.majorRelease != '' && format(' -- --release-as {1}', github.event.inputs.majorRelease) || '',
-        github.event.inputs.tag != '' && format(' --prerelease {1}', github.event.inputs.tag) || ''
-        }}
+        ${{ format('npm run release{}{}', github.event.inputs.majorRelease != '' && format(' -- --release-as {1}', github.event.inputs.majorRelease) || '',github.event.inputs.tag != '' && format(' --prerelease {1}', github.event.inputs.tag) || ''}}
 
     - name: Publish to npm
       run: |

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -14,7 +14,7 @@ on:
       tag:
         required: false
         type: string
-        description: 'Tag name. Leave empty for regular release.'
+        description: 'Prerelease tag name. Leave empty for regular release.'
 
 jobs:
   # integration-tests:

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -50,14 +50,14 @@ jobs:
 
     - name: Release
       run: |
-        npm run release ${{ github.event.inputs.majorRelease != '' && format('-- --release-as {1}', github.event.inputs.majorRelease) || '' }} ${{ github.event.inputs.tag != '' && format('--prerelease {1}', github.event.inputs.tag) || '' }}
+        npm run release ${{ github.event.inputs.majorRelease != '' && format('-- --release-as {0}', github.event.inputs.majorRelease) || '' }} ${{ github.event.inputs.tag != '' && format('--prerelease {0}', github.event.inputs.tag) || '' }}
 
     - name: Publish to npm
       run: |
         echo //registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_KEY}} >> .npmrc
         echo email=${{ secrets.NPM_EMAIL }} >> .npmrc
         echo always-auth=true >> .npmrc
-        npm publish ${{ github.events.inputs.tag != '' && format('--tag {1}', github.event.inputs.tag) || '' }}
+        npm publish ${{ github.events.inputs.tag != '' && format('--tag {0}', github.event.inputs.tag) || '' }}
 
     - name: Push git tags
       run: |

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -50,14 +50,14 @@ jobs:
 
     - name: Release
       run: |
-        ${{ format('npm run release{}{}', github.event.inputs.majorRelease != '' && format(' -- --release-as {1}', github.event.inputs.majorRelease) || '',github.event.inputs.tag != '' && format(' --prerelease {1}', github.event.inputs.tag) || ''}}
+        npm run release ${{ github.event.inputs.majorRelease != '' && format('-- --release-as {1}', github.event.inputs.majorRelease) || '' }} ${{ github.event.inputs.tag != '' && format('--prerelease {1}', github.event.inputs.tag) || '' }}
 
     - name: Publish to npm
       run: |
         echo //registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_KEY}} >> .npmrc
         echo email=${{ secrets.NPM_EMAIL }} >> .npmrc
         echo always-auth=true >> .npmrc
-        ${{ github.events.inputs.tag != '' && format('npm publish --tag {1}', github.event.inputs.tag) || 'npm publish' }}
+        npm publish ${{ github.events.inputs.tag != '' && format('--tag {1}', github.event.inputs.tag) || '' }}
 
     - name: Push git tags
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
       majorRelease:
         required: false
         description: 'Release as version. Example values are: minor, major, 5.6.1, 1.0.0. Leave empty for regular release.'
+      tag:
+        required: false
+        description: 'Tag name. Leave empty for regular release.'
 
 jobs:
   release:
@@ -13,4 +16,5 @@ jobs:
     with:
       branch: main
       majorRelease: ${{ inputs.majorRelease }}
+      tag: ${{ inputs.tag }}
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.0.0-alpha.0](https://github.com/firebolt-db/firebolt-node-sdk/compare/v0.2.5...v1.0.0-alpha.0) (2023-11-08)
+
+
+### Features
+
+* new identity support ([#43](https://github.com/firebolt-db/firebolt-node-sdk/issues/43)) ([a742cd6](https://github.com/firebolt-db/firebolt-node-sdk/commit/a742cd66fbcca9ef712ab07d43c5d9fbb1126119))
+* support create delete and attach database and engine ([#56](https://github.com/firebolt-db/firebolt-node-sdk/issues/56)) ([3bbc573](https://github.com/firebolt-db/firebolt-node-sdk/commit/3bbc5738507260a4e05e023903972b930e42f632))
+
 ### [0.2.5](https://github.com/firebolt-db/firebolt-node-sdk/compare/v0.2.4...v0.2.5) (2023-07-13)
 
 ### [0.2.4](https://github.com/firebolt-db/firebolt-node-sdk/compare/v0.2.3...v0.2.4) (2023-06-20)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebolt-sdk",
-  "version": "0.2.5",
+  "version": "1.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "firebolt-sdk",
-      "version": "0.2.5",
+      "version": "1.0.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-bigint": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebolt-sdk",
-  "version": "0.2.5",
+  "version": "1.0.0-alpha.0",
   "description": "Official firebolt Node.JS sdk",
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",


### PR DESCRIPTION
Added ability for pre-release in release workflow action
- For authentication, RELEASE_PAT secret is used now, which is bound to @stepansergeevitch user
- already released 1.0.0-alpha.0 version cannot be unpublished, therefore it's a part of this change