### PR TITLE
ci: inherit secrerts in release integration tests call

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   integration-tests:
     uses: ./.github/workflows/integration-tests.yaml
+    secrets: inherit
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add `secrets: inherit` parameter to integration tests call in release action