### PR TITLE
fix: bytea formatting for new ff 

### DIFF
--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -136,7 +136,11 @@ export class QueryFormatter {
   }
 
   private escapeBuffer(param: Buffer) {
-    return "'\\x" + param.toString("hex") + "'";
+    const bytesFormatted = [];
+    for (let i = 0; i < param.length; i++) {
+      bytesFormatted.push("\\x" + param[i].toString(16).padStart(2, "0"));
+    }
+    return "E'" + bytesFormatted.join("") + "'";
   }
 
   private escapeArray(param: unknown[], prefix = "[", suffix = "]") {

--- a/test/unit/statement.test.ts
+++ b/test/unit/statement.test.ts
@@ -273,7 +273,7 @@ describe("format query", () => {
     const formattedQuery = queryFormatter.formatQuery(query, [buffer]);
     // Jest escaping rules are different, so we need to double the amount of quotes compared to .toEqual()
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"SELECT 'hello_world'::bytea == '\\\\x68656c6c6f5f776f726c64'"`
+      `"SELECT 'hello_world'::bytea == E'\\\\x68\\\\x65\\\\x6c\\\\x6c\\\\x6f\\\\x5f\\\\x77\\\\x6f\\\\x72\\\\x6c\\\\x64'"`
     );
   });
 });


### PR DESCRIPTION
Implement a universal bytea formatting for both standard_conforming_strings enabled and disabled