### PR TITLE
feat: Add internal options to engine create

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -11,13 +11,9 @@ on:
         description: 'Prerelease tag name. Leave empty for regular release.'
 
 jobs:
-  integration-tests:
-    uses: ./.github/workflows/integration-tests.yaml
-    secrets: inherit
 
   publish:
     runs-on: ubuntu-latest
-    needs: integration-tests
     steps:    
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -11,9 +11,13 @@ on:
         description: 'Prerelease tag name. Leave empty for regular release.'
 
 jobs:
+  integration-tests:
+    uses: ./.github/workflows/integration-tests.yaml
+    secrets: inherit
 
   publish:
     runs-on: ubuntu-latest
+    needs: integration-tests
     steps:    
     - name: Check out code
       uses: actions/checkout@v2

--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -133,7 +133,6 @@ export class EngineService {
   }
 
   private getInternalOptions() {
-    console.log("Getting internal options");
     const internalOptions: Record<string, string> = {};
     for (const [env, optionName] of Object.entries(this.INTERNAL_OPTIONS)) {
       const optionValue = process.env[env];
@@ -168,10 +167,11 @@ export class EngineService {
 
     const internalOptions = this.getInternalOptions();
 
-    if (
-      Object.values(createOptions).some(v => v !== undefined) ||
-      internalOptions
-    ) {
+    const filteredCreateOptions = Object.entries(createOptions).filter(
+      ([, value]) => value !== undefined
+    );
+
+    if (filteredCreateOptions.length > 0 || internalOptions) {
       query += " WITH ";
     }
 

--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -23,7 +23,7 @@ export class EngineService {
   };
 
   private INTERNAL_OPTIONS: Record<string, string> = {
-    FIREBOLT_INTERNAL_VERSION: "VERSION"
+    FB_INTERNAL_OPTIONS_ENGINE_VERSION: "VERSION"
   };
 
   constructor(context: ResourceManagerContext) {

--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -167,15 +167,15 @@ export class EngineService {
 
     const internalOptions = this.getInternalOptions();
 
-    const filteredCreateOptions = Object.entries(createOptions).filter(
-      ([, value]) => value !== undefined
+    const filteredCreateOptions = Object.fromEntries(
+      Object.entries(createOptions).filter(([, value]) => value !== undefined)
     );
 
-    if (filteredCreateOptions.length > 0 || internalOptions) {
+    if (Object.keys(filteredCreateOptions).length > 0 || internalOptions) {
       query += " WITH ";
     }
 
-    for (const [key, value] of Object.entries(createOptions)) {
+    for (const [key, value] of Object.entries(filteredCreateOptions)) {
       if (key in createParameterNames) {
         if (key == "spec" && accountVersion >= 2) {
           // spec value is provided raw without quotes for accounts v2

--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -170,7 +170,7 @@ export class EngineService {
     // Exlude options that are not set or not allowed for the account version
     const filteredCreateOptions = Object.fromEntries(
       Object.entries(createOptions).filter(
-        ([, value]) => value !== undefined && value in createParameterNames
+        ([key, value]) => value !== undefined && key in createParameterNames
       )
     );
 
@@ -178,10 +178,7 @@ export class EngineService {
       query += " WITH ";
     }
 
-    const allOptions = Object.entries(filteredCreateOptions).concat(
-      Object.entries(internalOptions)
-    );
-    for (const [key, value] of allOptions) {
+    for (const [key, value] of Object.entries(filteredCreateOptions)) {
       if (key == "spec" && accountVersion >= 2) {
         // spec value is provided raw without quotes for accounts v2
         query += `${createParameterNames[key]} = ${value} `;
@@ -189,6 +186,11 @@ export class EngineService {
         query += `${createParameterNames[key]} = ? `;
         queryParameters.push(value);
       }
+    }
+
+    for (const [key, value] of Object.entries(internalOptions)) {
+      query += `${key} = ? `;
+      queryParameters.push(value);
     }
 
     await this.context.connection.execute(query, {

--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -133,11 +133,13 @@ export class EngineService {
   }
 
   private getInternalOptions() {
+    console.log("Getting internal options");
     const internalOptions: Record<string, string> = {};
     for (const [env, optionName] of Object.entries(this.INTERNAL_OPTIONS)) {
       const optionValue = process.env[env];
       if (optionValue) {
         internalOptions[optionName] = optionValue;
+        console.log(`Setting internal option ${optionName} to ${optionValue}`);
       }
     }
     return internalOptions;

--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -181,16 +181,18 @@ export class EngineService {
           // spec value is provided raw without quotes for accounts v2
           query += `${createParameterNames[key]} = ${value} `;
         } else {
-          query += `${createParameterNames[key]} = ?`;
+          query += `${createParameterNames[key]} = ? `;
           queryParameters.push(value);
         }
       }
     }
 
     // Add internal options to the query
-    query += `${Object.entries(internalOptions)
-      .map(([key, value]) => `${key} = '${value}'`)
-      .join(", ")}`;
+    query +=
+      " " +
+      `${Object.entries(internalOptions)
+        .map(([key, value]) => `${key} = '${value}'`)
+        .join(", ")}`;
 
     await this.context.connection.execute(query, {
       parameters: queryParameters

--- a/test/unit/v2/engine.test.ts
+++ b/test/unit/v2/engine.test.ts
@@ -395,7 +395,7 @@ describe("engine service", () => {
     });
     const resourceManager = firebolt.resourceManager;
 
-    process.env.FIREBOLT_INTERNAL_VERSION = engine_version;
+    process.env.FB_INTERNAL_OPTIONS_ENGINE_VERSION = engine_version;
 
     const engine = await resourceManager.engine.create("some_engine");
     expect(engine).toBeTruthy();


### PR DESCRIPTION
For CI we need to pass internal options to CREATE ENGINE query. Reading them from the environment to avoid changing the function signatures/API with rarely used parameters.