### PR TITLE
fix: reenable attach to database

### DIFF
--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -205,15 +205,13 @@ export class EngineService {
   ) {
     const accountVersion = (await this.context.connection.resolveAccountInfo())
       .infraVersion;
-    if (accountVersion >= 2) {
-      throw new DeprecationError({
-        message: "Attach engine is not supported for this account."
-      });
-    }
     const engine_name = engine instanceof EngineModel ? engine.name : engine;
     const database_name =
       database instanceof DatabaseModel ? database.name : database;
-    const query = `ATTACH ENGINE "${engine_name}" TO "${database_name}"`;
+    const query =
+      accountVersion == 1
+        ? `ATTACH ENGINE "${engine_name}" TO "${database_name}"`
+        : `ALTER ENGINE "${engine_name}" SET DEFAULT_DATABASE="${database_name}"`;
     await this.context.connection.execute(query);
   }
 }

--- a/test/integration/v2/engine.test.ts
+++ b/test/integration/v2/engine.test.ts
@@ -145,12 +145,7 @@ describe.each([
       expect(engine.name == name);
 
       const accountId = (await connection.resolveAccountInfo()).infraVersion;
-      if (accountId == 1) {
-        await firebolt.resourceManager.engine.attachToDatabase(
-          engine,
-          database
-        );
-      }
+      await firebolt.resourceManager.engine.attachToDatabase(engine, database);
       const attached_engines = await database.getAttachedEngines();
       expect(attached_engines.includes(engine));
 


### PR DESCRIPTION
Reenabled attaching database and engine for account v2. We use a different syntax now, `ALTER ENGINE .. SET DEFAULT_DATABASE=..` intead of `ATTACH ENGINE .. TO ..`