### PR TITLE
fix: Skip empty engine parameters

### DIFF
--- a/src/service/engine/index.ts
+++ b/src/service/engine/index.ts
@@ -170,7 +170,8 @@ export class EngineService {
     // Exlude options that are not set or not allowed for the account version
     const filteredCreateOptions = Object.fromEntries(
       Object.entries(createOptions).filter(
-        ([key, value]) => value !== undefined && key in createParameterNames
+        ([key, value]) =>
+          value !== undefined && value !== "" && key in createParameterNames
       )
     );
 

--- a/test/unit/v2/engine.test.ts
+++ b/test/unit/v2/engine.test.ts
@@ -380,6 +380,7 @@ describe("engine service", () => {
           if (requestBody.includes("CREATE ENGINE")) {
             expect(requestBody).toContain(`ENGINE_TYPE = 'GENERAL_PURPOSE'`);
             expect(requestBody).not.toContain(`REGION`);
+            expect(requestBody).not.toContain(`SPEC`);
           }
           return res(ctx.json(selectEngineResponse));
         }
@@ -396,7 +397,8 @@ describe("engine service", () => {
     const resourceManager = firebolt.resourceManager;
     const engine = await resourceManager.engine.create("some_engine", {
       region: undefined,
-      engine_type: "GENERAL_PURPOSE"
+      engine_type: "GENERAL_PURPOSE",
+      spec: ""
     });
     expect(engine).toBeTruthy();
     expect(engine.endpoint).toEqual("https://some_engine.com");


### PR DESCRIPTION
This skips parameters that are defined as empty as well as unknown.