### PR TITLE
fix: add support for engine v2 statuses

### DIFF
--- a/src/service/engine/types.ts
+++ b/src/service/engine/types.ts
@@ -12,7 +12,9 @@ export function processEngineStatus(
   // Translate status from db to an EngineStatusSummary object
   const enumKey = Object.keys(EngineStatusSummary).find(
     key =>
-      EngineStatusSummary[key as keyof typeof EngineStatusSummary] === value
+      EngineStatusSummary[
+        key as keyof typeof EngineStatusSummary
+      ].toLowerCase() === value.toLowerCase()
   );
   if (enumKey !== undefined) {
     return EngineStatusSummary[enumKey as keyof typeof EngineStatusSummary];

--- a/test/unit/v2/engine.test.ts
+++ b/test/unit/v2/engine.test.ts
@@ -7,6 +7,10 @@ import { ResourceManager } from "../../../src/service";
 import { ConnectionError, DeprecationError } from "../../../src/common/errors";
 import { NodeHttpClient } from "../../../src/http/node";
 import { Authenticator } from "../../../src/auth";
+import {
+  processEngineStatus,
+  EngineStatusSummary
+} from "../../../src/service/engine/types";
 
 const apiEndpoint = "api.fake.firebolt.io";
 
@@ -434,5 +438,11 @@ describe("engine service", () => {
     expect(engine.endpoint).toEqual("https://some_engine.com");
 
     delete process.env.ENGINE_NAME;
+  });
+  it("Parses different engine statuses correctly", async () => {
+    const statuses = ["RUNNING", "Running", "running"];
+    for (const status of statuses) {
+      expect(processEngineStatus(status)).toEqual(EngineStatusSummary.RUNNING);
+    }
   });
 });


### PR DESCRIPTION
Added support for engines v2 status values, which are fully uppercase instead of capitalized in v1. `RUNNING` vs `Running`