### PR TITLE
test: Engine v2 and v1 compatible tests

### DIFF
--- a/test/integration/v2/bytea.test.ts
+++ b/test/integration/v2/bytea.test.ts
@@ -54,7 +54,9 @@ describe("bytea", () => {
 
     const connection = await firebolt.connect(connectionParams);
 
-    await connection.execute("CREATE TABLE bytea_test (id int, data bytea)");
+    await connection.execute(
+      "CREATE TABLE bytea_test (id int, data bytea not null)"
+    );
     const bytea_value = Buffer.from("hello_world_123ツ\n\u0048");
 
     await connection.execute("INSERT INTO bytea_test VALUES (1, ?::bytea)", {

--- a/test/integration/v2/index.test.ts
+++ b/test/integration/v2/index.test.ts
@@ -139,19 +139,6 @@ describe("integration test", () => {
     const row = data[0];
     expect(row).toMatchObject({ "1": 1 });
   });
-  it("async query", async () => {
-    const firebolt = Firebolt({
-      apiEndpoint: process.env.FIREBOLT_API_ENDPOINT as string
-    });
-
-    const connection = await firebolt.connect(connectionParams);
-    const statement = await connection.execute("SELECT 1", {
-      settings: { async_execution: true },
-      response: { normalizeData: false }
-    });
-    const result = await statement.fetchResult();
-    expect(result.query_id).toBeTruthy();
-  });
   it("returns Date type", async () => {
     const firebolt = Firebolt({
       apiEndpoint: process.env.FIREBOLT_API_ENDPOINT as string
@@ -200,10 +187,12 @@ describe("integration test", () => {
 
     const statement = await connection.execute(
       `
-    WITH arr AS (
-        SELECT [1,2,3,4,5,6] as a
-    )
-    SELECT a FROM arr UNNEST(a)`,
+      SELECT 1 AS value UNION ALL
+      SELECT 2 UNION ALL
+      SELECT 3 UNION ALL
+      SELECT 4 UNION ALL
+      SELECT 5 UNION ALL
+      SELECT 6`,
       {
         settings: {
           output_format: OutputFormat.JSON_COMPACT
@@ -273,10 +262,12 @@ describe("integration test", () => {
 
     const statement = await connection.execute(
       `
-    WITH arr AS (
-        SELECT [1,2,3,4,5,6] as a
-    )
-    SELECT a FROM arr UNNEST(a)`
+      SELECT 1 AS value UNION ALL
+      SELECT 2 UNION ALL
+      SELECT 3 UNION ALL
+      SELECT 4 UNION ALL
+      SELECT 5 UNION ALL
+      SELECT 6`
     );
 
     // to achieve seamless stream pipes you can use through2

--- a/test/integration/v2/systemEngine.test.ts
+++ b/test/integration/v2/systemEngine.test.ts
@@ -38,13 +38,20 @@ describe("system engine", () => {
     try {
       await connection.execute(`create database if not exists ${databaseName}`);
 
-      await connection.execute(
-        `create engine if not exists ${engineName} with REGION = 'us-east-1' SPEC = 'B1' SCALE = 1`
-      );
+      const acc_version = (await connection.resolveAccountInfo()).infraVersion;
 
-      await connection.execute(
-        `attach engine ${engineName} to ${databaseName}`
-      );
+      if (acc_version === 1) {
+        await connection.execute(
+          `create engine if not exists ${engineName} with SPEC = 'B1' SCALE = 1`
+        );
+        await connection.execute(
+          `attach engine ${engineName} to ${databaseName}`
+        );
+      } else {
+        await connection.execute(
+          `create engine if not exists ${engineName} with TYPE=S NODES=1`
+        );
+      }
     } catch (error) {
       console.log(error);
       expect(true).toEqual(false);
@@ -61,6 +68,7 @@ describe("system engine", () => {
     });
 
     try {
+      await connection.execute(`stop engine ${engineName}`);
       await connection.execute(`drop engine if exists ${engineName}`);
       await connection.execute(`drop database if exists ${databaseName}`);
     } catch (error) {


### PR DESCRIPTION
FIR-33220

Making most tests not break once we migrate the testing account to v2.
Only thing left will be to remove v1 config from resource manager tests.

- Unnest is not implemented yet so I've replaced it with a simpler query.
- Async execution is finally dropped.
- Columns default to null so one of the tests had `meta[0].type` to be `bytea null`. Not sure if expected, but to avoid this in test I'm setting it to not null explicitly.