### PR TITLE
feat: In memory token caching

### DIFF
--- a/src/common/tokenCache.ts
+++ b/src/common/tokenCache.ts
@@ -49,8 +49,8 @@ export class InMemoryCache implements TokenCache {
     const record = this.storage[key];
     if (this.isExpired(record)) {
       this.clearCachedToken(clientId, secret);
+      return null;
     }
-    console.log(`Returning cached token ${record}`);
     return record;
   }
 
@@ -62,7 +62,6 @@ export class InMemoryCache implements TokenCache {
   ): void {
     const key = this.makeKey(clientId, secret);
     const expiration = Date.now() + expiresIn;
-    console.log(`Caching token ${token} for key ${key}`);
     this.storage[key] = {
       token,
       expiration

--- a/src/common/tokenCache.ts
+++ b/src/common/tokenCache.ts
@@ -41,7 +41,7 @@ export class InMemoryCache implements TokenCache {
   }
 
   private isExpired(record: TokenRecord): boolean {
-    return record && Date.now() > record.expiration;
+    return record && Date.now() > record.expiration * 1000;
   }
 
   getCachedToken(clientId: string, secret: string): TokenRecord | null {

--- a/src/common/tokenCache.ts
+++ b/src/common/tokenCache.ts
@@ -41,7 +41,7 @@ export class InMemoryCache implements TokenCache {
   }
 
   private isExpired(record: TokenRecord): boolean {
-    return record && Date.now() > record.expiration * 1000;
+    return record && Date.now() > record.expiration;
   }
 
   getCachedToken(clientId: string, secret: string): TokenRecord | null {
@@ -61,7 +61,7 @@ export class InMemoryCache implements TokenCache {
     expiresIn: number
   ): void {
     const key = this.makeKey(clientId, secret);
-    const expiration = Date.now() + expiresIn;
+    const expiration = Date.now() + expiresIn * 1000;
     this.storage[key] = {
       token,
       expiration

--- a/src/common/tokenCache.ts
+++ b/src/common/tokenCache.ts
@@ -1,0 +1,79 @@
+export type TokenRecord = {
+  token: string;
+  expiration: number;
+};
+
+export interface TokenCache {
+  getCachedToken(clientId: string, secret: string): TokenRecord | null;
+  cacheToken(
+    clientId: string,
+    secret: string,
+    token: string,
+    expiresIn: number
+  ): void;
+  clearCachedToken(clientId: string, secret: string): void;
+}
+
+export class NoneCache implements TokenCache {
+  getCachedToken(clientId: string, secret: string): TokenRecord | null {
+    return null;
+  }
+
+  cacheToken(
+    clientId: string,
+    secret: string,
+    token: string,
+    expiresIn: number
+  ): void {
+    // Do nothing
+  }
+
+  clearCachedToken(): void {
+    // Do nothing
+  }
+}
+
+export class InMemoryCache implements TokenCache {
+  private storage: Record<string, TokenRecord> = {};
+
+  private makeKey(clientId: string, secret: string): string {
+    return `${clientId}:${secret}`;
+  }
+
+  private isExpired(record: TokenRecord): boolean {
+    return record && Date.now() > record.expiration;
+  }
+
+  getCachedToken(clientId: string, secret: string): TokenRecord | null {
+    const key = this.makeKey(clientId, secret);
+    const record = this.storage[key];
+    if (this.isExpired(record)) {
+      this.clearCachedToken(clientId, secret);
+    }
+    console.log(`Returning cached token ${record}`);
+    return record;
+  }
+
+  cacheToken(
+    clientId: string,
+    secret: string,
+    token: string,
+    expiresIn: number
+  ): void {
+    const key = this.makeKey(clientId, secret);
+    const expiration = Date.now() + expiresIn;
+    console.log(`Caching token ${token} for key ${key}`);
+    this.storage[key] = {
+      token,
+      expiration
+    };
+  }
+
+  clearCachedToken(clientId: string, secret: string): void {
+    const key = this.makeKey(clientId, secret);
+    delete this.storage[key];
+  }
+}
+
+export const inMemoryCache = new InMemoryCache();
+export const noneCache = new NoneCache();

--- a/src/http/node.ts
+++ b/src/http/node.ts
@@ -115,7 +115,14 @@ export class NodeHttpClient {
           });
         }
 
-        const request = this.request<T>(method, url, options);
+        // Manually unpack options because of typing issues
+        // Force set retry to false to avoid infinite loop
+        const request = this.request<T>(method, url, {
+          headers: options?.headers ?? {},
+          body: options?.body,
+          raw: options?.raw,
+          retry: false
+        });
         return request.ready();
       }
 

--- a/src/http/node.ts
+++ b/src/http/node.ts
@@ -107,6 +107,7 @@ export class NodeHttpClient {
 
       if (response.status === 401 && retry) {
         try {
+          this.authenticator.clearCache();
           await this.authenticator.authenticate();
         } catch (error) {
           throw new AuthenticationError({

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export type ConnectionOptions = {
   additionalParameters?: AdditionalConnectionParameters;
   account?: string;
   auth: AuthOptions;
+  useCache?: boolean;
 };
 
 export type FireboltClientOptions = {

--- a/test/unit/http.test.ts
+++ b/test/unit/http.test.ts
@@ -4,6 +4,7 @@ import { Authenticator } from "../../src/auth";
 import { NodeHttpClient } from "../../src/http/node";
 import { Logger } from "../../src/logger/node";
 import { QueryFormatter } from "../../src/formatter";
+import { AuthOptions } from "../../src/types";
 
 const apiEndpoint = "api.fake.firebolt.io";
 const logger = new Logger();
@@ -124,5 +125,139 @@ describe.each([
     );
     await authenticator.authenticate();
     await httpClient.request("POST", `${apiEndpoint}/engines`).ready();
+  });
+});
+
+describe.each([
+  [
+    "username/password",
+    `https://${apiEndpoint}/auth/v1/login`,
+    { username: "fake_client", password: "fake_secret" }
+  ],
+  [
+    "client_id/client_secret",
+    `https://id.fake.firebolt.io/oauth/token`,
+    { client_id: "fake_client", client_secret: "fake_secret" }
+  ]
+])("token caching %s", (_, authUrl: string, auth: AuthOptions) => {
+  const server = setupServer();
+  const httpClient = new NodeHttpClient();
+  const queryFormatter = new QueryFormatter();
+
+  beforeAll(() => {
+    server.listen();
+  });
+  afterAll(() => {
+    server.close();
+  });
+
+  it("caches and reuses access token", async () => {
+    const authenticator = new Authenticator(
+      { queryFormatter, httpClient, apiEndpoint, logger },
+      {
+        auth,
+        account: "my_account",
+        useCache: true
+      }
+    );
+
+    let calls = 0;
+
+    server.use(
+      rest.post(authUrl, (req, res, ctx) => {
+        calls++;
+        return res(
+          ctx.json({
+            access_token: "fake_access_token",
+            expires_in: 2 ^ 30
+          })
+        );
+      })
+    );
+
+    authenticator.clearCache();
+
+    await authenticator.authenticate();
+    expect(authenticator.accessToken).toEqual("fake_access_token");
+    await authenticator.authenticate();
+    expect(authenticator.accessToken).toEqual("fake_access_token");
+    expect(calls).toEqual(1);
+  });
+
+  it("refreshes token if expired", async () => {
+    const authenticator = new Authenticator(
+      { queryFormatter, httpClient, apiEndpoint, logger },
+      {
+        auth,
+        account: "my_account",
+        useCache: true
+      }
+    );
+
+    let calls = 0;
+
+    server.use(
+      rest.post(authUrl, (req, res, ctx) => {
+        calls++;
+        return res(
+          ctx.json({
+            access_token: "fake_access_token",
+            refresh_token: "fake_refresh_token",
+            expires_in: -100
+          })
+        );
+      })
+    );
+
+    authenticator.clearCache();
+
+    await authenticator.authenticate();
+    expect(authenticator.accessToken).toEqual("fake_access_token");
+    await authenticator.authenticate();
+    expect(authenticator.accessToken).toEqual("fake_access_token");
+    expect(calls).toEqual(2);
+  });
+
+  it("disregards cache on 401 error", async () => {
+    const authenticator = new Authenticator(
+      { queryFormatter, httpClient, apiEndpoint, logger },
+      {
+        auth,
+        account: "my_account",
+        useCache: true
+      }
+    );
+
+    let calls = 0;
+
+    server.use(
+      rest.post(authUrl, (req, res, ctx) => {
+        calls++;
+        return res(
+          ctx.json({
+            access_token: "fake_access_token",
+            expires_in: 2 ^ 30
+          })
+        );
+      }),
+      rest.post(`https://${apiEndpoint}/engines`, (req, res, ctx) => {
+        return res(
+          ctx.status(401),
+          ctx.json({
+            message: "Unauthorized",
+            code: 401
+          })
+        );
+      })
+    );
+
+    authenticator.clearCache();
+    await authenticator.authenticate();
+
+    await expect(async () => {
+      await httpClient.request("POST", `${apiEndpoint}/engines`).ready();
+    }).rejects.toThrow("Unauthorized");
+
+    expect(calls).toEqual(2);
   });
 });


### PR DESCRIPTION
Added in-memory token caching to node sdk since we have a lot of 429 error in tests. Also this feature should generally reduce the amount of http requests