### PR TITLE
ci: Add nightly tests

### DIFF
--- a/.github/workflows/integration-tests-v2.yaml
+++ b/.github/workflows/integration-tests-v2.yaml
@@ -1,23 +1,25 @@
-name: Run integration tests for 2.0
+name: Nightly code check
 on:
   workflow_dispatch:
-  workflow_call:
-    secrets:
-      FIREBOLT_CLIENT_ID_STG_NEW_IDN:
-        required: true
-      FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
-        required: true
+  schedule:
+    - cron: '0 6 * * *' # 6 am UTC every day
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # finish all jobs even if one fails
+      max-parallel: 2
+      matrix:
+        os: ['macos-latest', 'windows-latest', 'ubuntu-latest']
+        node-version: ['16', '18', '20', '22']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm install
@@ -28,14 +30,13 @@ jobs:
         with:
           firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
           firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
-          account: ${{ vars.FIREBOLT_ACCOUNT_V1 }}
+          account: ${{ vars.FIREBOLT_ACCOUNT }}
           api-endpoint: "api.staging.firebolt.io"
-          region: "us-east-1"
+          db_suffix: ${{ format('{0}_{1}', matrix.os, matrix.node-version) }}
 
       - name: Run integration tests
         env:
-          FIREBOLT_ACCOUNT_V1: ${{ vars.FIREBOLT_ACCOUNT_V1 }}
-          FIREBOLT_ACCOUNT_V2: ${{ vars.FIREBOLT_ACCOUNT_V2 }}
+          FIREBOLT_ACCOUNT: ${{ vars.FIREBOLT_ACCOUNT }}
           FIREBOLT_DATABASE: ${{ steps.setup.outputs.database_name }}
           FIREBOLT_ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
           FIREBOLT_API_ENDPOINT: "api.staging.firebolt.io"
@@ -44,20 +45,13 @@ jobs:
         run: |
           npm run test:ci integration/v2
 
-      # Need to pull the pages branch in order to fetch the previous runs
-      - name: Get Allure history
-        uses: actions/checkout@v2
-        if: always()
-        continue-on-error: true
+      - name: Slack Notify of failure
+        if: failure()
+        id: slack
+        uses: firebolt-db/action-slack-nightly-notify@v1
         with:
-            ref: gh-pages
-            path: gh-pages
-
-      - name: Allure Report
-        uses: firebolt-db/action-allure-report@main
-        if: always()
-        with:
-            github-key: ${{ secrets.GITHUB_TOKEN }}
-            test-type: integration
-            allure-dir: allure-results
-            pages-branch: gh-pages
+          os: ${{ matrix.os }}
+          programming-language: Node
+          language-version: ${{ matrix.node-version }}
+          notifications-channel: 'ecosystem-ci-notifications'
+          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/integration-tests-v2.yaml
+++ b/.github/workflows/integration-tests-v2.yaml
@@ -1,25 +1,23 @@
-name: Nightly code check
+name: Run integration tests for 2.0
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * *' # 6 am UTC every day
+  workflow_call:
+    secrets:
+      FIREBOLT_CLIENT_ID_STG_NEW_IDN:
+        required: true
+      FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
+        required: true
 jobs:
   tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false # finish all jobs even if one fails
-      max-parallel: 2
-      matrix:
-        os: ['macos-latest', 'windows-latest', 'ubuntu-latest']
-        node-version: ['16', '18', '20', '22']
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
 
       - name: Set up node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
 
       - name: Install dependencies
         run: npm install
@@ -30,13 +28,14 @@ jobs:
         with:
           firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
           firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
-          account: ${{ vars.FIREBOLT_ACCOUNT }}
+          account: ${{ vars.FIREBOLT_ACCOUNT_V1 }}
           api-endpoint: "api.staging.firebolt.io"
-          db_suffix: ${{ format('{0}_{1}', matrix.os, matrix.node-version) }}
+          region: "us-east-1"
 
       - name: Run integration tests
         env:
-          FIREBOLT_ACCOUNT: ${{ vars.FIREBOLT_ACCOUNT }}
+          FIREBOLT_ACCOUNT_V1: ${{ vars.FIREBOLT_ACCOUNT_V1 }}
+          FIREBOLT_ACCOUNT_V2: ${{ vars.FIREBOLT_ACCOUNT_V2 }}
           FIREBOLT_DATABASE: ${{ steps.setup.outputs.database_name }}
           FIREBOLT_ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
           FIREBOLT_API_ENDPOINT: "api.staging.firebolt.io"
@@ -45,13 +44,20 @@ jobs:
         run: |
           npm run test:ci integration/v2
 
-      - name: Slack Notify of failure
-        if: failure()
-        id: slack
-        uses: firebolt-db/action-slack-nightly-notify@v1
+      # Need to pull the pages branch in order to fetch the previous runs
+      - name: Get Allure history
+        uses: actions/checkout@v2
+        if: always()
+        continue-on-error: true
         with:
-          os: ${{ matrix.os }}
-          programming-language: Node
-          language-version: ${{ matrix.node-version }}
-          notifications-channel: 'ecosystem-ci-notifications'
-          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}
+            ref: gh-pages
+            path: gh-pages
+
+      - name: Allure Report
+        uses: firebolt-db/action-allure-report@main
+        if: always()
+        with:
+            github-key: ${{ secrets.GITHUB_TOKEN }}
+            test-type: integration
+            allure-dir: allure-results
+            pages-branch: gh-pages

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false # finish all jobs even if one fails
       max-parallel: 2
       matrix:
-        os: ['macos-13', 'windows-latest', 'ubuntu-latest']
+        os: ['macos-latest', 'windows-latest', 'ubuntu-latest']
         node-version: ['16', '18', '20', '22']
     steps:
       - name: Check out code

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 2
       matrix:
         os: ['macos-latest', 'windows-latest', 'ubuntu-latest']
-        node-version: ['16', '18', '20', '22']
+        node-version: ['18', '20', '22']
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,59 @@
+name: Nightly code check
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *' # 6 am UTC every day
+jobs:
+  code-check:
+    uses: ./.github/workflows/code-check.yml
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # finish all jobs even if one fails
+      max-parallel: 2
+      matrix:
+        os: ['macos-13', 'windows-latest', 'ubuntu-latest']
+        node-version: ['16', '18', '20', '22']
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Setup database and engine
+        id: setup
+        uses: firebolt-db/integration-testing-setup@v2
+        with:
+          firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+          firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
+          account: ${{ vars.FIREBOLT_ACCOUNT }}
+          api-endpoint: "api.staging.firebolt.io"
+          db_suffix: ${{ format('{0}_{1}', matrix.os, matrix.node-version) }}
+
+      - name: Run integration tests
+        env:
+          FIREBOLT_ACCOUNT: ${{ vars.FIREBOLT_ACCOUNT }}
+          FIREBOLT_DATABASE: ${{ steps.setup.outputs.database_name }}
+          FIREBOLT_ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
+          FIREBOLT_API_ENDPOINT: "api.staging.firebolt.io"
+          FIREBOLT_CLIENT_ID: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+          FIREBOLT_CLIENT_SECRET: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
+        run: |
+          npm run test:ci integration/v2
+
+      - name: Slack Notify of failure
+        if: failure()
+        id: slack
+        uses: firebolt-db/action-slack-nightly-notify@v1
+        with:
+          os: ${{ matrix.os }}
+          programming-language: Node
+          language-version: ${{ matrix.node-version }}
+          notifications-channel: 'ecosystem-ci-notifications'
+          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 6 * * *' # 6 am UTC every day
 jobs:
-  code-check:
-    uses: ./.github/workflows/code-check.yml
   tests:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
version 16 is the earliest supported by us.
22 is the latest "current" version.
Odd numbered versions are not included as they have no long-term support.
More info - https://nodejs.org/en/about/previous-releases