### PR TITLE
fix(FIR-34534): Properly parsing bigint

### DIFF
--- a/src/statement/hydrateResponse.ts
+++ b/src/statement/hydrateResponse.ts
@@ -46,6 +46,9 @@ const getHydratedValue = (
     ) {
       return value.toString();
     }
+    if (typeof value === "string" && type === "long") {
+      return new BigNumber(value);
+    }
     return value;
   }
   if (isByteAType(type) && value != null) {

--- a/test/integration/v2/fetchTypes.test.ts
+++ b/test/integration/v2/fetchTypes.test.ts
@@ -6,7 +6,7 @@ const connectionParams = {
     client_id: process.env.FIREBOLT_CLIENT_ID as string,
     client_secret: process.env.FIREBOLT_CLIENT_SECRET as string
   },
-  account: process.env.FIREBOLT_ACCOUNT_V1 as string,
+  account: process.env.FIREBOLT_ACCOUNT as string,
   database: process.env.FIREBOLT_DATABASE as string
 };
 

--- a/test/integration/v2/fetchTypes.test.ts
+++ b/test/integration/v2/fetchTypes.test.ts
@@ -12,8 +12,8 @@ const connectionParams = {
 
 jest.setTimeout(100000);
 
-describe("types", () => {
-  it("handles select boolean", async () => {
+describe("test type casting on fetch", () => {
+  it("select boolean", async () => {
     const firebolt = Firebolt({
       apiEndpoint: process.env.FIREBOLT_API_ENDPOINT as string
     });
@@ -27,7 +27,7 @@ describe("types", () => {
     const row = data[0];
     expect((row as unknown[])[0]).toEqual(true);
   });
-  it("handles select bigint", async () => {
+  it("select bigint", async () => {
     const firebolt = Firebolt({
       apiEndpoint: process.env.FIREBOLT_API_ENDPOINT as string
     });
@@ -42,7 +42,7 @@ describe("types", () => {
     const row = data[0];
     expect((row as unknown[])[0]).toEqual(new BigNumber("9223372036854775807"));
   });
-  it("handles select negative bigint", async () => {
+  it("select negative bigint", async () => {
     const firebolt = Firebolt({
       apiEndpoint: process.env.FIREBOLT_API_ENDPOINT as string
     });

--- a/test/integration/v2/fetchTypes.test.ts
+++ b/test/integration/v2/fetchTypes.test.ts
@@ -1,0 +1,62 @@
+import { Firebolt } from "../../../src/index";
+import BigNumber from "bignumber.js";
+
+const connectionParams = {
+  auth: {
+    client_id: process.env.FIREBOLT_CLIENT_ID as string,
+    client_secret: process.env.FIREBOLT_CLIENT_SECRET as string
+  },
+  account: process.env.FIREBOLT_ACCOUNT_V1 as string,
+  database: process.env.FIREBOLT_DATABASE as string
+};
+
+jest.setTimeout(100000);
+
+describe("types", () => {
+  it("handles select boolean", async () => {
+    const firebolt = Firebolt({
+      apiEndpoint: process.env.FIREBOLT_API_ENDPOINT as string
+    });
+
+    const connection = await firebolt.connect(connectionParams);
+
+    const statement = await connection.execute("select true::boolean");
+
+    const { data, meta } = await statement.fetchResult();
+    expect(meta[0].type).toEqual("boolean");
+    const row = data[0];
+    expect((row as unknown[])[0]).toEqual(true);
+  });
+  it("handles select bigint", async () => {
+    const firebolt = Firebolt({
+      apiEndpoint: process.env.FIREBOLT_API_ENDPOINT as string
+    });
+
+    const connection = await firebolt.connect(connectionParams);
+
+    // Max value for a signed 64-bit integer (bigint)
+    const statement = await connection.execute("select 9223372036854775807");
+
+    const { data, meta } = await statement.fetchResult();
+    expect(meta[0].type).toEqual("long");
+    const row = data[0];
+    expect((row as unknown[])[0]).toEqual(new BigNumber("9223372036854775807"));
+  });
+  it("handles select negative bigint", async () => {
+    const firebolt = Firebolt({
+      apiEndpoint: process.env.FIREBOLT_API_ENDPOINT as string
+    });
+
+    const connection = await firebolt.connect(connectionParams);
+
+    // Max negative value for a signed 64-bit integer (bigint)
+    const statement = await connection.execute("select -9223372036854775808");
+
+    const { data, meta } = await statement.fetchResult();
+    expect(meta[0].type).toEqual("long");
+    const row = data[0];
+    expect((row as unknown[])[0]).toEqual(
+      new BigNumber("-9223372036854775808")
+    );
+  });
+});

--- a/test/unit/statement.test.ts
+++ b/test/unit/statement.test.ts
@@ -7,8 +7,9 @@ import {
   Tuple
 } from "../../src/formatter";
 import { hydrateRow } from "../../src/statement/hydrateResponse";
+import "allure-jest";
 
-describe("format query", () => {
+describe("query formatting", () => {
   it("format", () => {
     const queryFormatter = new QueryFormatter();
     const query = "select ? from table";
@@ -298,7 +299,10 @@ describe("parse values", () => {
     expect(isNaN(res["pnan"])).toBe(true);
     expect(isNaN(res["nnan"])).toBe(true);
   });
-  it("parses bigint", () => {
+  it("parses bigint into BigNumber container", () => {
+    allure.description(
+      "JS natively doesn't support bigint so we use BigNumber container"
+    );
     const row = {
       big: "1000000000000000000000000000000000000"
     };

--- a/test/unit/statement.test.ts
+++ b/test/unit/statement.test.ts
@@ -298,6 +298,17 @@ describe("parse values", () => {
     expect(isNaN(res["pnan"])).toBe(true);
     expect(isNaN(res["nnan"])).toBe(true);
   });
+  it("parses bigint", () => {
+    const row = {
+      big: "1000000000000000000000000000000000000"
+    };
+    const meta = [{ name: "big", type: "long" }];
+    const res: Record<string, BigNumber> = hydrateRow(row, meta, {});
+    expect(res["big"] instanceof BigNumber).toBe(true);
+    expect(res["big"]).toEqual(
+      new BigNumber(1000000000000000000000000000000000000)
+    );
+  });
 });
 
 describe("set statements", () => {


### PR DESCRIPTION
Bigint is sent to us in a string in JSON so JSONParser can no longer parse it properly into an appropriate container. In this change we're checking the metadata and if not converted - convert to a BigNumber container.

Renamed boolean.test to dataType.test since it was counter-productive to keep a single test in a file.