### PR TITLE
chore: set min node version to 16

### DIFF
--- a/.github/workflows/integration-tests-v1.yaml
+++ b/.github/workflows/integration-tests-v1.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Set up node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '16'
     

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -20,13 +20,13 @@ jobs:
     needs: integration-tests
     steps:    
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_PAT }}
     
     - name: Set up node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '16'
     

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ console.log(rows)
 ## About
 The Firebolt client for Node.js. firebolt-sdk provides common methods for quering Firebolt databases, fetching and streaming results, and engine management.
 
-firebolt-sdk supports  Node.js `> v14`.
+firebolt-sdk supports  Node.js `> v16`.
 
 <a id="documentation"></a>
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
   "engines": {
-    "node": ">=12.0"
+    "node": ">=16.0"
   },
   "scripts": {
     "build": "rm -fr ./build && tsc -p tsconfig.lib.json",


### PR DESCRIPTION
Initially attempted in #112 but some tools depend on us supporting node 16.
Standardising this across the doc and ci.