### PR TITLE
String escape and tokenization for Firebolt 2

### DIFF
--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -2,18 +2,10 @@ import BigNumber from "bignumber.js";
 import { checkArgumentValid, zeroPad } from "../common/util";
 import { INVALID_PARAMETERS } from "../common/errors";
 
-const CHARS_GLOBAL_REGEXP = /[\0\b\t\n\r\x1a"'\\]/g; // eslint-disable-line no-control-regex
+const CHARS_GLOBAL_REGEXP = /'/g;
 
 const CHARS_ESCAPE_MAP: Record<string, string> = {
-  "\0": "\\0",
-  "\b": "\\b",
-  "\t": "\\t",
-  "\n": "\\n",
-  "\r": "\\r",
-  "\x1a": "\\Z",
-  '"': '\\"',
-  "'": "\\'",
-  "\\": "\\\\"
+  "'": "''"
 };
 const SET_PREFIX = "set ";
 
@@ -47,15 +39,14 @@ export class QueryFormatter {
     params = [...params];
 
     // Matches:
-    // - ' strings with \ escapes
-    // - " strings with \ escapes
+    // - ' strings without escapes, 'foo''bar' matches as two strings and it's alright
+    // - " strings without escapes, "foo""bar" matches as two strings and it's alright
     // - /* */ comments
     // - -- comments
     // - ? parameters
     // - :: operator
     // - :named parameters
-    const tokenizer =
-      /'(?:[^'\\]+|\\.)*'|"(?:[^"\\]+|\\.)*"|\/\*[\s\S]*\*\/|--.*|(\?)|::|:(\w+)/g;
+    const tokenizer = /'[^']*'|"[^"]*"|\/\*[\s\S]*?\*\/|--.*|(\?)|::|:(\w+)/g;
 
     query = query.replace(
       tokenizer,

--- a/test/unit/statement.test.ts
+++ b/test/unit/statement.test.ts
@@ -39,20 +39,18 @@ describe("query formatting", () => {
     const formattedQuery = queryFormatter.formatQuery(query, ["foo?"]);
     expect(formattedQuery).toMatchInlineSnapshot(`"select 'foo?' from table"`);
   });
-  it("format \n", () => {
+  it("format new line", () => {
     const queryFormatter = new QueryFormatter();
     const query = "select ? from table";
     const formattedQuery = queryFormatter.formatQuery(query, ["foo\nbar"]);
-    expect(formattedQuery).toMatchInlineSnapshot(
-      `"select 'foo\\nbar' from table"`
-    );
+    expect(formattedQuery).toBe(`select 'foo\nbar' from table`);
   });
   it("format '", () => {
     const queryFormatter = new QueryFormatter();
     const query = "select ? from table";
     const formattedQuery = queryFormatter.formatQuery(query, ["foo'bar"]);
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"select 'foo\\'bar' from table"`
+      `"select 'foo''bar' from table"`
     );
   });
 
@@ -67,19 +65,21 @@ describe("query formatting", () => {
   it("format array", () => {
     const queryFormatter = new QueryFormatter();
     const query = "select ? from table";
-    const formattedQuery = queryFormatter.formatQuery(query, [["foo", 'bar"']]);
+    const formattedQuery = queryFormatter.formatQuery(query, [
+      ["foo'", 'bar"']
+    ]);
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"select ['foo', 'bar\\"'] from table"`
+      `"select ['foo''', 'bar"'] from table"`
     );
   });
   it("format nested array", () => {
     const queryFormatter = new QueryFormatter();
     const query = "select ? from table";
     const formattedQuery = queryFormatter.formatQuery(query, [
-      ["foo", ["foo", 'bar"']]
+      ["foo", ["foo'", 'bar"']]
     ]);
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"select ['foo', ['foo', 'bar\\"']] from table"`
+      `"select ['foo', ['foo''', 'bar"']] from table"`
     );
   });
   it("escape bignumber", () => {
@@ -145,10 +145,10 @@ describe("query formatting", () => {
   it("format with comments in strings", () => {
     const queryFormatter = new QueryFormatter();
     const query =
-      "SELECT 'str \\' ? -- not comment', /* comment? */ ? -- comment?";
+      "SELECT 'str '' ? -- not comment', /* comment? */ ? -- comment?";
     const formattedQuery = queryFormatter.formatQuery(query, ["foo"]);
     expect(formattedQuery).toMatchInlineSnapshot(
-      `"SELECT 'str \\' ? -- not comment', /* comment? */ 'foo' -- comment?"`
+      `"SELECT 'str '' ? -- not comment', /* comment? */ 'foo' -- comment?"`
     );
   });
   it("format tuple", () => {


### PR DESCRIPTION
Change string escapes to Firebolt 2 style, as it does not support backslashes as escape character.

This breaks Firebolt 1 escaping tho. So needs to be made version dependent somehow.