### PR TITLE
feat(FIR-37168): testConnection doesn't reset autostop timer

### DIFF
--- a/.github/workflows/integration-tests-v1.yaml
+++ b/.github/workflows/integration-tests-v1.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Setup database and engine
         id: setup
-        uses: firebolt-db/integration-testing-setup@v1
+        uses: firebolt-db/integration-testing-setup@v1-error
         with:
           firebolt-username: ${{ secrets.FIREBOLT_STG_USERNAME }}
           firebolt-password: ${{ secrets.FIREBOLT_STG_PASSWORD }}

--- a/.github/workflows/integration-tests-v1.yaml
+++ b/.github/workflows/integration-tests-v1.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Setup database and engine
         id: setup
-        uses: firebolt-db/integration-testing-setup@v1-error
+        uses: firebolt-db/integration-testing-setup@v1
         with:
           firebolt-username: ${{ secrets.FIREBOLT_STG_USERNAME }}
           firebolt-password: ${{ secrets.FIREBOLT_STG_PASSWORD }}

--- a/src/connection/base.ts
+++ b/src/connection/base.ts
@@ -54,6 +54,8 @@ export abstract class Connection {
 
   abstract resolveEngineEndpoint(): Promise<string>;
 
+  abstract testConnection(): Promise<void>;
+
   protected getRequestUrl(executeQueryOptions: ExecuteQueryOptions): string {
     const params = this.getBaseParameters(executeQueryOptions);
 

--- a/src/connection/base.ts
+++ b/src/connection/base.ts
@@ -81,7 +81,15 @@ export abstract class Connection {
     const strSettings = Object.entries(settings ?? {}).reduce<
       Record<string, string>
     >((acc, [key, value]) => {
-      if (value !== undefined) {
+      if (key === "internal") {
+        // Unwrap internal settings from array
+        const internalSettings = value as Record<string, string | number>[];
+        internalSettings.forEach(setting => {
+          Object.entries(setting).forEach(([internalKey, internalValue]) => {
+            acc[internalKey] = internalValue.toString();
+          });
+        });
+      } else if (value !== undefined) {
         acc[key] = value.toString();
       }
       return acc;

--- a/src/connection/connection_v1.ts
+++ b/src/connection/connection_v1.ts
@@ -59,4 +59,8 @@ export class ConnectionV1 extends BaseConnection {
     }
     return this.accountInfo;
   }
+
+  async testConnection() {
+    await this.execute("select 1");
+  }
 }

--- a/src/connection/connection_v2.ts
+++ b/src/connection/connection_v2.ts
@@ -69,4 +69,9 @@ export class ConnectionV2 extends BaseConnection {
 
     return this.engineEndpoint;
   }
+
+  async testConnection() {
+    const settings = { internal: [{ auto_start_stop_control: "ignore" }] };
+    await this.execute("select 1", { settings });
+  }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,11 +1,6 @@
 import { makeConnection } from "../connection";
 import { Authenticator } from "../auth";
-import {
-  Context,
-  ConnectionOptions,
-  FireboltClientOptions,
-  SettingValues
-} from "../types";
+import { Context, ConnectionOptions, FireboltClientOptions } from "../types";
 import { ResourceManager } from "../service";
 
 export class FireboltCore {
@@ -38,7 +33,7 @@ export class FireboltCore {
     await connection.resolveEngineEndpoint();
     // auto_start_stop_control is only available for v2
     const settings = auth.isServiceAccount()
-      ? { auto_start_stop_control: SettingValues.IGNORE }
+      ? { internal: [{ auto_start_stop_control: "ignore" }] }
       : {};
     await connection.execute("select 1", { settings });
   }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -36,8 +36,10 @@ export class FireboltCore {
     const connection = makeConnection(this.context, connectionOptions);
     await auth.authenticate();
     await connection.resolveEngineEndpoint();
-    await connection.execute("select 1", {
-      settings: { auto_start_stop_control: SettingValues.IGNORE }
-    });
+    // auto_start_stop_control is only available for v2
+    const settings = auth.isServiceAccount()
+      ? { auto_start_stop_control: SettingValues.IGNORE }
+      : {};
+    await connection.execute("select 1", { settings });
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -31,10 +31,6 @@ export class FireboltCore {
     const connection = makeConnection(this.context, connectionOptions);
     await auth.authenticate();
     await connection.resolveEngineEndpoint();
-    // auto_start_stop_control is only available for v2
-    const settings = auth.isServiceAccount()
-      ? { internal: [{ auto_start_stop_control: "ignore" }] }
-      : {};
-    await connection.execute("select 1", { settings });
+    await connection.testConnection();
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,11 @@
 import { makeConnection } from "../connection";
 import { Authenticator } from "../auth";
-import { Context, ConnectionOptions, FireboltClientOptions } from "../types";
+import {
+  Context,
+  ConnectionOptions,
+  FireboltClientOptions,
+  SettingValues
+} from "../types";
 import { ResourceManager } from "../service";
 
 export class FireboltCore {
@@ -31,6 +36,8 @@ export class FireboltCore {
     const connection = makeConnection(this.context, connectionOptions);
     await auth.authenticate();
     await connection.resolveEngineEndpoint();
-    await connection.execute("select 1");
+    await connection.execute("select 1", {
+      settings: { auto_start_stop_control: SettingValues.IGNORE }
+    });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,11 +29,16 @@ export enum OutputFormat {
   JSON = "JSON"
 }
 
+export enum SettingValues {
+  IGNORE = "ignore"
+}
+
 export type QuerySettings = Record<
   string,
   string | number | boolean | undefined
 > & {
   output_format?: OutputFormat;
+  auto_start_stop_control?: SettingValues;
 };
 
 export type RowParser = (row: string, isLastRow: boolean) => any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,16 +29,12 @@ export enum OutputFormat {
   JSON = "JSON"
 }
 
-export enum SettingValues {
-  IGNORE = "ignore"
-}
-
 export type QuerySettings = Record<
   string,
-  string | number | boolean | undefined
+  string | number | boolean | undefined | Record<string, string | number>[]
 > & {
   output_format?: OutputFormat;
-  auto_start_stop_control?: SettingValues;
+  internal?: Record<string, string | number>[];
 };
 
 export type RowParser = (row: string, isLastRow: boolean) => any;

--- a/test/unit/connection.test.ts
+++ b/test/unit/connection.test.ts
@@ -493,6 +493,36 @@ INFO: SYNTAX_ERROR - Unexpected character at {"failingLine":42,"startOffset":120
     expect(searchParamsUsed.get("param")).toEqual("value");
   });
 
+  it("handles settings in execute", async () => {
+    server.use(
+      rest.post(`https://some_engine.com`, async (req, res, ctx) => {
+        const body = await req.text();
+        const urlParams = Object.fromEntries(req.url.searchParams.entries());
+        expect(urlParams).toHaveProperty("param");
+        if (body.startsWith("SELECT 1")) {
+          return res(ctx.json(emptyResponse));
+        }
+      })
+    );
+
+    const connectionParams: ConnectionOptions = {
+      auth: {
+        client_id: "dummy",
+        client_secret: "dummy"
+      },
+      database: "dummy",
+      engineName: "dummy",
+      account: "my_account"
+    };
+    const firebolt = Firebolt({
+      apiEndpoint
+    });
+
+    const connection = await firebolt.connect(connectionParams);
+    await connection.execute("SELECT 1", { settings: { param: "value" } });
+  });
+
+
   it("handles invalid set statements correctly", async () => {
     let searchParamsUsed = new URLSearchParams();
     let searchParamsUsed2 = new URLSearchParams();

--- a/test/unit/v1/connection.test.ts
+++ b/test/unit/v1/connection.test.ts
@@ -159,6 +159,8 @@ describe("Connection v1", () => {
 
     const connection = await firebolt.connect(connectionParams);
     await connection.testConnection();
+    // also test the method from core
+    await firebolt.testConnection(connectionParams);
   });
   it("Can run set statements", async () => {
     const param = "my_var";

--- a/test/unit/v1/connection.test.ts
+++ b/test/unit/v1/connection.test.ts
@@ -3,7 +3,6 @@ import { rest } from "msw";
 import { ConnectionOptions, Firebolt } from "../../../src";
 import { ConnectionV1 } from "../../../src/connection/connection_v1";
 
-
 const apiEndpoint = "fake.api.com";
 const accountName = "my_account";
 
@@ -135,6 +134,31 @@ describe("Connection v1", () => {
       connection as unknown as ConnectionV1
     ).resolveAccountInfo();
     expect(account_info.id).toBe("some_account");
+  });
+  it("testConnection works", async () => {
+    // override select 1 response and check within it that query parameter is not set
+    server.use(
+      rest.post(`https://some_engine.com/`, (req, res, ctx) => {
+        const urlParams = Object.fromEntries(req.url.searchParams.entries());
+        expect(urlParams).not.toContain("auto_start_stop_control");
+        return res(ctx.json(selectOneResponse));
+      })
+    );
+
+    const firebolt = Firebolt({ apiEndpoint });
+
+    const connectionParams: ConnectionOptions = {
+      auth: {
+        username: "user",
+        password: "pass"
+      },
+      database: "dummy",
+      engineName: "dummy",
+      account: accountName
+    };
+
+    const connection = await firebolt.connect(connectionParams);
+    await connection.testConnection();
   });
   it("Can run set statements", async () => {
     const param = "my_var";

--- a/test/unit/v2/connection.test.ts
+++ b/test/unit/v2/connection.test.ts
@@ -205,6 +205,8 @@ describe("Connection V2", () => {
 
     const connection = await firebolt.connect(connectionParams);
     await connection.testConnection();
+    // also test the method from core
+    await firebolt.testConnection(connectionParams);
   });
   it("respects useCache option", async () => {
     const firebolt = Firebolt({

--- a/test/unit/v2/connection.test.ts
+++ b/test/unit/v2/connection.test.ts
@@ -162,6 +162,50 @@ describe("Connection V2", () => {
 
     expect(engineUrlCalls).toBe(1);
   });
+  it("testConnection works", async () => {
+    const firebolt = Firebolt({
+      apiEndpoint
+    });
+
+    server.use(
+      rest.post(`https://id.fake.firebolt.io/oauth/token`, (req, res, ctx) => {
+        return res(
+          ctx.json({
+            access_token: "fake_access_token"
+          })
+        );
+      }),
+      rest.get(
+        `https://api.fake.firebolt.io/web/v3/account/my_account/engineUrl`,
+        (req, res, ctx) => {
+          return res(
+            ctx.json({
+              engineUrl: "https://some_system_engine.com"
+            })
+          );
+        }
+      ),
+      rest.post(
+        `https://some_system_engine.com/${QUERY_URL}`,
+        (req, res, ctx) => {
+          const urlParams = Object.fromEntries(req.url.searchParams.entries());
+          expect(urlParams).toHaveProperty("auto_start_stop_control");
+          return res(ctx.json(engineUrlResponse));
+        }
+      )
+    );
+
+    const connectionParams: ConnectionOptions = {
+      auth: {
+        client_id: "dummy",
+        client_secret: "dummy"
+      },
+      account: "my_account"
+    };
+
+    const connection = await firebolt.connect(connectionParams);
+    await connection.testConnection();
+  });
   it("respects useCache option", async () => {
     const firebolt = Firebolt({
       apiEndpoint


### PR DESCRIPTION
This method is used by Cube.js to verify connection is working. However, every time it's used the timer on engine auto stop is reset. We want to let engine spin down despite the constant healthchecks if no other queries are running.