### PR TITLE
tests: fix boolean check

### DIFF
--- a/test/integration/v2/date.test.ts
+++ b/test/integration/v2/date.test.ts
@@ -20,7 +20,7 @@ description TEXT NULL,
 pg_date pgdate NOT NULL ,
 time_wtz timestamptz NOT NULL ,
 time_ntz timestampntz NOT NULL ,
-done boolean NOT NULL default 1
+done boolean NOT NULL default true
 )
 PRIMARY INDEX id;
 `;


### PR DESCRIPTION
We've switched to true booleans. 1 and 0 no longer substitute true and false.