### PR TITLE
fix(FIR-43473): stop engine without starting it again

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -32,7 +32,7 @@ jobs:
         npm test -- --coverage test/unit
         
     - name: "Security Scan"
-      uses: SonarSource/sonarcloud-github-action@master
+      uses: SonarSource/sonarqube-scan-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}

--- a/src/service/engine/model.ts
+++ b/src/service/engine/model.ts
@@ -36,11 +36,11 @@ export class EngineModel {
   async stop() {
     const query = `STOP ENGINE "${this.name}"`;
     await this.connection.execute(query);
-    await this.refreshStatus();
     const res: Engine = {
       name: this.name,
       endpoint: this.endpoint,
-      current_status_summary: this.current_status_summary
+      // Successful request means the engine is stopped
+      current_status_summary: EngineStatusSummary.STOPPED
     };
     return { engine: res };
   }


### PR DESCRIPTION
Currently when we stop an engine we check for its status, which causes it to start again if we run on that engine. This shouldn't be the case. We can safely assume if the request has succeeded that means the operation is successful. This means we can just report a Stopped state without the additional request.