### PR TITLE
fix(FIR-44193): auth concurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,13 @@
         "abort-controller": "^3.0.0",
         "agentkeepalive": "^4.5.0",
         "json-bigint": "^1.0.0",
-        "node-fetch": "^2.6.6"
+        "node-fetch": "^2.6.6",
+        "rwlock": "^5.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node-fetch": "^2.5.12",
+        "@types/rwlock": "^5.0.6",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "allure-commandline": "^2.29.0",
@@ -1458,6 +1460,13 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/rwlock": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rwlock/-/rwlock-5.0.6.tgz",
+      "integrity": "sha512-JcjZjGATVC+LoLd910jIEkbSVQpvxRvAhHqIYCl9sf0qvKp+m2ps/WfthQRqWUcE38pgiD6YqEQ5tK4oSNK1XA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.2",
@@ -7649,6 +7658,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rwlock": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz",
+      "integrity": "sha512-XgzRqLMfCcm9QfZuPav9cV3Xin5TRcIlp4X/SH3CvB+x5D2AakdlEepfJKDd8ByncvfpcxNWdRZVUl38PS6ZJg==",
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
@@ -9928,6 +9943,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/rwlock": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rwlock/-/rwlock-5.0.6.tgz",
+      "integrity": "sha512-JcjZjGATVC+LoLd910jIEkbSVQpvxRvAhHqIYCl9sf0qvKp+m2ps/WfthQRqWUcE38pgiD6YqEQ5tK4oSNK1XA==",
       "dev": true
     },
     "@types/set-cookie-parser": {
@@ -14479,6 +14500,11 @@
       "requires": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "rwlock": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz",
+      "integrity": "sha512-XgzRqLMfCcm9QfZuPav9cV3Xin5TRcIlp4X/SH3CvB+x5D2AakdlEepfJKDd8ByncvfpcxNWdRZVUl38PS6ZJg=="
     },
     "rxjs": {
       "version": "7.5.6",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node-fetch": "^2.5.12",
+    "@types/rwlock": "^5.0.6",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "allure-commandline": "^2.29.0",
@@ -46,6 +47,7 @@
     "abort-controller": "^3.0.0",
     "agentkeepalive": "^4.5.0",
     "json-bigint": "^1.0.0",
-    "node-fetch": "^2.6.6"
+    "node-fetch": "^2.6.6",
+    "rwlock": "^5.0.0"
   }
 }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -23,7 +23,7 @@ export class Authenticator {
   options: ConnectionOptions;
 
   accessToken?: string;
-  private rwlock = new ReadWriteLock();
+  private readonly rwlock = new ReadWriteLock();
 
   constructor(context: Context, options: ConnectionOptions) {
     context.httpClient.authenticator = this;
@@ -179,8 +179,9 @@ export class Authenticator {
           releaseReadLock();
           resolve(cachedToken);
         } catch (error) {
+          // Make sure to avoid deadlocks in case of errors
           releaseReadLock();
-          reject(error);
+          reject(error instanceof Error ? error : new Error(String(error)));
         }
       });
     });
@@ -203,8 +204,9 @@ export class Authenticator {
           releaseWriteLock();
           resolve();
         } catch (error) {
+          // Make sure to avoid deadlocks in case of errors
           releaseWriteLock();
-          reject(error);
+          reject(error instanceof Error ? error : new Error(String(error)));
         }
       });
     });

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -176,12 +176,11 @@ export class Authenticator {
       this.rwlock.readLock(releaseReadLock => {
         try {
           const cachedToken = this.getCachedToken();
-          releaseReadLock();
           resolve(cachedToken);
         } catch (error) {
-          // Make sure to avoid deadlocks in case of errors
-          releaseReadLock();
           reject(error instanceof Error ? error : new Error(String(error)));
+        } finally {
+          releaseReadLock();
         }
       });
     });
@@ -201,12 +200,11 @@ export class Authenticator {
 
           await this.performAuthentication();
 
-          releaseWriteLock();
           resolve();
         } catch (error) {
-          // Make sure to avoid deadlocks in case of errors
-          releaseWriteLock();
           reject(error instanceof Error ? error : new Error(String(error)));
+        } finally {
+          releaseWriteLock();
         }
       });
     });

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -194,7 +194,6 @@ export class Authenticator {
           const cachedToken = this.getCachedToken();
           if (cachedToken) {
             this.accessToken = cachedToken;
-            releaseWriteLock();
             return resolve();
           }
 

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -26,13 +26,9 @@ export class Authenticator {
   private rwlock = new ReadWriteLock();
 
   constructor(context: Context, options: ConnectionOptions) {
+    context.httpClient.authenticator = this;
     this.context = context;
     this.options = options;
-    if (context.httpClient.authenticator) {
-      return context.httpClient.authenticator;
-    } else {
-      context.httpClient.authenticator = this;
-    }
   }
 
   private getCacheKey(): TokenKey | undefined {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,7 +14,7 @@ export class FireboltCore {
     this.options = options;
   }
 
-  async connect(connectionOptions: ConnectionOptions) {
+  private async prepareConnection(connectionOptions: ConnectionOptions) {
     // Create a new httpClient instance for each connection
     const httpClient =
       this.options.dependencies?.httpClient || new NodeHttpClient();
@@ -29,6 +29,14 @@ export class FireboltCore {
     const connection = makeConnection(connectionContext, connectionOptions);
     await auth.authenticate();
     await connection.resolveEngineEndpoint();
+
+    return { connection, connectionContext };
+  }
+
+  async connect(connectionOptions: ConnectionOptions) {
+    const { connection, connectionContext } = await this.prepareConnection(
+      connectionOptions
+    );
     const resourceContext = {
       connection,
       ...connectionContext
@@ -38,20 +46,7 @@ export class FireboltCore {
   }
 
   async testConnection(connectionOptions: ConnectionOptions) {
-    // Create a new httpClient instance for test connection too
-    const httpClient =
-      this.options.dependencies?.httpClient || new NodeHttpClient();
-
-    // Create a new context with the new httpClient
-    const connectionContext = {
-      ...this.context,
-      httpClient
-    };
-
-    const auth = new Authenticator(connectionContext, connectionOptions);
-    const connection = makeConnection(connectionContext, connectionOptions);
-    await auth.authenticate();
-    await connection.resolveEngineEndpoint();
+    const { connection } = await this.prepareConnection(connectionOptions);
     await connection.testConnection();
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -16,7 +16,8 @@ export class FireboltCore {
 
   async connect(connectionOptions: ConnectionOptions) {
     // Create a new httpClient instance for each connection
-    const httpClient = new NodeHttpClient();
+    const httpClient =
+      this.options.dependencies?.httpClient || new NodeHttpClient();
 
     // Create a new context with the new httpClient
     const connectionContext = {
@@ -38,7 +39,8 @@ export class FireboltCore {
 
   async testConnection(connectionOptions: ConnectionOptions) {
     // Create a new httpClient instance for test connection too
-    const httpClient = new NodeHttpClient();
+    const httpClient =
+      this.options.dependencies?.httpClient || new NodeHttpClient();
 
     // Create a new context with the new httpClient
     const connectionContext = {

--- a/test/unit/http.test.ts
+++ b/test/unit/http.test.ts
@@ -166,7 +166,7 @@ describe.each([
         return res(
           ctx.json({
             access_token: "fake_access_token",
-            expires_in: 2 ^ 30
+            expires_in: 2 ** 30
           })
         );
       })
@@ -233,7 +233,7 @@ describe.each([
         return res(
           ctx.json({
             access_token: "fake_access_token",
-            expires_in: 2 ^ 30
+            expires_in: 2 ** 30
           })
         );
       }),
@@ -276,7 +276,7 @@ describe.each([
         return res(
           ctx.json({
             access_token: "fake_access_token",
-            expires_in: 2 ^ 30
+            expires_in: 2 ** 30
           })
         );
       })
@@ -322,7 +322,7 @@ describe.each([
         return res(
           ctx.json({
             access_token: "fake_access_token",
-            expires_in: 2 ^ 30
+            expires_in: 2 ** 30
           })
         );
       }),
@@ -331,7 +331,7 @@ describe.each([
         return res(
           ctx.json({
             access_token: "fake_access_token",
-            expires_in: 2 ^ 30
+            expires_in: 2 ** 30
           })
         );
       })
@@ -364,7 +364,7 @@ describe.each([
         return res(
           ctx.json({
             access_token: "fake_access_token",
-            expires_in: 2 ^ 30
+            expires_in: 2 ** 30
           })
         );
       })


### PR DESCRIPTION
Simplified diagram of the auth/execute flow before this change below. As you can see, there's a strict dependency between Authenticator and httpClient. Behind the scenes on auth failure httpclient would re-authenticate. This is where the issues arose, when concurrent requests would share an httpClient, invalidate the cache and write new values. However, since the whole process is async another request would come in, read invalidated cache value and fail to authenticate. In loop this led to many 403's stacking.
In this change we make sure that http client is not shared, which solves the issue of the race condition. Also, introducing locking mechanism to ensure we don't have multiple processes trying to authenticate at the same time.
![image](https://github.com/user-attachments/assets/34572776-a4f8-466c-b33b-e563c12e873a)
